### PR TITLE
Update cpp_builder.py to build a correct compilation command on Windows

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -811,7 +811,10 @@ def _get_python_related_args() -> Tuple[List[str], List[str]]:
 
     if _IS_WINDOWS:
         python_path = os.path.dirname(sys.executable)
-        python_lib_path = [os.path.join(python_path, "libs")]
+        if "conda-meta" in os.listdir(sys.prefix):
+            python_lib_path = [os.path.join(python_path, "libs")]
+        else:
+            python_lib_path = [os.path.join(sys.base_prefix, "libs")]
     else:
         python_lib_path = [sysconfig.get_config_var("LIBDIR")]
 
@@ -1438,7 +1441,7 @@ class CppBuilder:
 
         for inc_dir in BuildOption.get_include_dirs():
             if _IS_WINDOWS:
-                self._include_dirs_args += f"/I {inc_dir} "
+                self._include_dirs_args += f'/I "{inc_dir}" '
             else:
                 self._include_dirs_args += f"-I{inc_dir} "
 


### PR DESCRIPTION
Fix the issue with torch.compile on Windows due to spaces in the path and virtual environment setup.
1. Wrap include paths in double quotes:
To handle paths with spaces, enclose the header file paths in double quotes. This ensures the compiler treats the entire path as a single argument.

2. Adapt library linkage to the virtual environment type:
Dynamically determine the correct library path based on the type of virtual environment being used, ensuring the linker can find and use the necessary libraries like python310.lib.

Fixes #141026
